### PR TITLE
Remove downstream dependency on true

### DIFF
--- a/META.json
+++ b/META.json
@@ -48,8 +48,7 @@
             "autobox" : "0",
             "autobox::Core" : "0",
             "parent" : "0",
-            "perl" : "5.010",
-            "true" : "0"
+            "perl" : "5.010"
          }
       },
       "test" : {

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ requires 'perl', '5.008001';
 
 requires 'autobox';
 requires 'autobox::Core';
-requires 'true';
 requires 'Carp';
 requires 'parent';
 requires 'Sort::Maker';

--- a/lib/autobox/Transform.pm
+++ b/lib/autobox/Transform.pm
@@ -211,7 +211,6 @@ particular when the values are hashrefs or objects.
 
 
 
-use true;
 use Carp;
 
 sub import {
@@ -2139,3 +2138,5 @@ This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.
 
 =cut
+
+1;


### PR DESCRIPTION
Trading the location of a single line of code may not seem like much, however `true` will, for reasons unknown, not build when the file path includes a space due to some upstream issue with ExtUtils::Depends.

Would have patched upstream, but in all honesty removing a dependency from the river seems like a bigger win.

Note, this may be a Windows specific bug, havent got a linux box handy to test it on...